### PR TITLE
Add "make coremark", which produces a binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,7 @@ ifdef ETC
 # Targets related to testing and releasing CoreMark. Not part of the general release!
 include Makefile.internal
 endif	
+
+# A shim so freedom-metal can be built
+coremark:
+	$(MAKE) PORT_DIR=freedom-metal link


### PR DESCRIPTION
This makes the freedom-metal integration a bit easier.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>